### PR TITLE
feat(ci): Add Build and Push Workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,76 @@
+name: Build and Push
+
+on:
+  push:
+    paths:
+      - 'jenkins/**'
+      - 'dind-agent/**'
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - 'jenkins/**'
+      - 'dind-agent/**'
+
+env:
+  REPO: ${{ vars.REPO }}
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      REPO: ${{ env.REPO }}
+    steps:
+      -
+        name: Prepare Outputs
+        run: |
+          echo "REPO=${{ env.REPO }}" >> $GITHUB_OUTPUT
+
+
+  build-and-push:
+    needs: [prepare-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - path: ./jenkins
+            image: ${{ needs.prepare-matrix.outputs.REPO }}/jenkins-server
+          - path: ./dind-agent
+            image: ${{ needs.prepare-matrix.outputs.REPO }}/jenkins-agent
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db #3.6.1
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=head
+      -
+        name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build Image
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
+        with:
+          context: ${{ matrix.path }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          file: ${{ matrix.path }}/Dockerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+vendor
+.kube/
+.vscode/
+.DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Misc
+*.pem
+
+# act
+*.secrets

--- a/dind-agent/Dockerfile
+++ b/dind-agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/jnlp-agent-docker
+FROM jenkins/jnlp-agent-docker@sha256:eb9ab5139a598c3a210d5a491d3cc31db501cb870b011035e9cdbc0b5e661dfa 
+# Base image v3261.v9c670a_4748a_9, from the labels
 ENV PYTHONUNBUFFERED=1
 USER root
 
@@ -12,4 +13,4 @@ RUN pip3 install --no-cache --upgrade pip setuptools "jenkins-job-builder==5.1.0
 RUN export PATH="/home/jenkins/.local/bin:$PATH"
 
 USER jenkins
-ENTRYPOINT "/entrypoint.sh"
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Add a workflow: builds images when a PR points designated branch and dirs, builds and pushes images when designated branches and dirs are pushed or tagged.

Closes second part of [rancher-qa/#1464](https://github.com/rancher/qa-tasks/issues/1464)


Both PR and Push look for: 
   
```
 paths:
      - 'jenkins/**'
      - 'dind-agent/**'
    branches:
      - "master"
```

If a PR happens, without logging into docker, docker load/build happens.

If a merge/push happens to the master branch, the head version gets updated.
if a tag push happens, the latest and that semver version tags are pushed.


**Required Workflow Variables:**

- [IMAGE_OWNER environment variable](https://github.com/bmdepesa/jenkins-casc/pull/1/files#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeR20)
- [DOCKER_USERNAME and DOCKER_PASSWORD secrets](https://github.com/bmdepesa/jenkins-casc/pull/1/files#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeR65-R66)